### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 env:
   NODE_ENV: test
   CI: true


### PR DESCRIPTION
Potential fix for [https://github.com/alexgutscher26/WaitListNow/security/code-scanning/3](https://github.com/alexgutscher26/WaitListNow/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only needs to read repository contents (e.g., to install dependencies and run tests), we will set `contents: read` at the workflow level. This will apply the minimal required permissions to all jobs in the workflow. If any job requires additional permissions in the future, they can be specified at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
