### PR TITLE
Potential fix for code scanning alert no. 36: Information exposure through a stack trace

### DIFF
--- a/src/app/api/waitlists/[id]/route.ts
+++ b/src/app/api/waitlists/[id]/route.ts
@@ -302,7 +302,6 @@ async function handleUpdateWaitlist(req: NextRequest, waitlistId: string, isFull
       return new NextResponse(
         JSON.stringify({
           error: error.message,
-          stack: isDev ? error.stack : undefined,
         }),
         {
           status: 500,
@@ -311,10 +310,16 @@ async function handleUpdateWaitlist(req: NextRequest, waitlistId: string, isFull
       );
     }
 
+    // Log the error details on the server
+    console.error('[WAITLISTS_UPDATE] Internal server error:', {
+      message: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : undefined,
+      error,
+    });
+
     return new NextResponse(
       JSON.stringify({
         error: 'Internal server error',
-        details: isDev ? String(error) : undefined,
       }),
       {
         status: 500,


### PR DESCRIPTION
Potential fix for [https://github.com/alexgutscher26/WaitListNow/security/code-scanning/36](https://github.com/alexgutscher26/WaitListNow/security/code-scanning/36)

To fix the issue, we will ensure that stack traces and detailed error information are never exposed to the user, even in development environments. Instead, we will log the error details on the server and return a generic error message to the user. This involves modifying the error-handling logic to remove any references to `error.stack` or `String(error)` in the response payload. We will also ensure that detailed error logging remains available for debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
