### PR TITLE
Potential fix for code scanning alert no. 34: Information exposure through a stack trace

### DIFF
--- a/src/app/api/waitlists/[id]/route.ts
+++ b/src/app/api/waitlists/[id]/route.ts
@@ -156,23 +156,18 @@ export async function DELETE(req: NextRequest, { params }: { params: { id: strin
   } catch (error) {
     console.error('[WAITLISTS_DELETE]', error);
 
+    // Log the error details, including the stack trace, for debugging purposes
     if (error instanceof Error) {
-      return new NextResponse(
-        JSON.stringify({
-          error: error.message,
-          stack: isDev ? error.stack : undefined,
-        }),
-        {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        },
-      );
+      console.error('Error message:', error.message);
+      console.error('Stack trace:', error.stack);
+    } else {
+      console.error('Unexpected error:', String(error));
     }
 
+    // Return a generic error message to the user
     return new NextResponse(
       JSON.stringify({
         error: 'Internal server error',
-        details: isDev ? String(error) : undefined,
       }),
       {
         status: 500,


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/alexgutscher26/WaitListNow/security/code-scanning/34](https://github.com/alexgutscher26/WaitListNow/security/code-scanning/34)

To fix the issue, we will ensure that stack trace information and other sensitive details are never exposed to the user, even in development mode. Instead, we will log the error details (including the stack trace) on the server and return a generic error message in the response. This approach aligns with best practices for error handling and prevents accidental exposure of sensitive information.

Specifically:
1. Remove the conditional inclusion of `error.stack` and `String(error)` in the response body.
2. Log the error details (including the stack trace) to the server console or a logging system.
3. Return a generic error message, such as "Internal server error," in the response body.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **Description**
- Enhanced error handling to prevent exposure of sensitive information in responses.
- Implemented logging of error details on the server for debugging purposes.
- Returned a generic error message ("Internal server error") to users.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Improve error handling to prevent information exposure</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/waitlists/[id]/route.ts
<li>Removed sensitive error details from the response.<br> <li> Added logging for error messages and stack traces.<br> <li> Returned a generic error message to the user.<br>


</details>


  </td>
  <td><a href="https://github.com/alexgutscher26/WaitListNow/pull/78/files#diff-9d6f74d7354054b9db0be7ed6046bbbd673f05c10f6d8a7cb47d6a06f94591dd">+6/-11</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

